### PR TITLE
Fix warn message use latest-image 

### DIFF
--- a/pkg/scanner/scan.go
+++ b/pkg/scanner/scan.go
@@ -34,7 +34,7 @@ func ScanImage(imageName, filePath string) (map[string][]vulnerability.DetectedV
 		return nil, xerrors.Errorf("invalid image: %w", err)
 	}
 	if image.Tag == "latest" {
-		log.Logger.Warn("You should avoid using the :latest tag as it is cached. You need to specify '--clean' option when :latest image is changed")
+		log.Logger.Warn("You should avoid using the :latest tag as it is cached. You need to specify '--clear-cache' option when :latest image is changed")
 	}
 
 	var target string


### PR DESCRIPTION
I think this is a forgot fix of the commit.
https://github.com/knqyf263/trivy/commit/9a67f0d1a77dd77ffdbe233a175572df2af018f1

Could you delete warn message, if --clear-cache option true. 