### PR TITLE
check yarn.lock in node scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ See [Comparison with other scanners](#comparison-with-other-scanners) for detail
 # Abstract
 
 `Trivy` (`tri` pronounced like **tri**gger, `vy` pronounced like en**vy**) is a simple and comprehensive vulnerability scanner for containers.
-`Trivy` detects vulnerabilities of OS packages (Alpine, RHEL, CentOS, etc.) and application dependencies (Bundler, Composer, npm, etc.).
+`Trivy` detects vulnerabilities of OS packages (Alpine, RHEL, CentOS, etc.) and application dependencies (Bundler, Composer, npm, yarn etc.).
 `Trivy` is easy to use. Just install the binary and you're ready to scan. All you need to do for scanning is to specify a container image name.
 
 It is considered to be used in CI. Before pushing to a container registry, you can scan your local container image easily.
@@ -68,7 +68,7 @@ See [here](#continuous-integration-ci) for details.
 
 - Detect comprehensive vulnerabilities
   - OS packages (Alpine, **Red Hat Universal Base Image**, Red Hat Enterprise Linux, CentOS, Debian and Ubuntu)
-  - **Application dependencies** (Bundler, Composer, Pipenv, npm and Cargo)
+  - **Application dependencies** (Bundler, Composer, Pipenv, npm, yarn and Cargo)
 - Simple
   - Specify only an image name
 - Easy installation
@@ -481,6 +481,7 @@ Repository: https://github.com/knqyf263/trivy-ci-test
 - Pipfile.lock
 - composer.lock
 - package-lock.json
+- yarn.lock
 - Cargo.lock
 
 The path of these files does not matter.

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/genuinetools/reg v0.16.0
 	github.com/gliderlabs/ssh v0.1.3 // indirect
 	github.com/golang/protobuf v1.3.1 // indirect
-	github.com/knqyf263/fanal v0.0.0-20190514052804-ca40e6cb0e1a
+	github.com/knqyf263/fanal v0.0.0-20190516002914-a1530cdb9a80
 	github.com/knqyf263/go-deb-version v0.0.0-20170509080151-9865fe14d09b
-	github.com/knqyf263/go-dep-parser v0.0.0-20190511063217-d5d543bfc261
+	github.com/knqyf263/go-dep-parser v0.0.0-20190515172517-b8305876c9c2
 	github.com/knqyf263/go-rpm-version v0.0.0-20170716094938-74609b86c936
 	github.com/knqyf263/go-version v1.1.1
 	github.com/mattn/go-colorable v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,10 +116,14 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/knqyf263/berkeleydb v0.0.0-20190501065933-fafe01fb9662/go.mod h1:bu1CcN4tUtoRcI/B/RFHhxMNKFHVq/c3SV+UTyduoXg=
 github.com/knqyf263/fanal v0.0.0-20190514052804-ca40e6cb0e1a h1:2zG9YY77/Nv+dMcAA3EzRwoUWP0cWmQIuAumhEYZtNQ=
 github.com/knqyf263/fanal v0.0.0-20190514052804-ca40e6cb0e1a/go.mod h1:HTp1oNm2dPtIooJCspQHukx37GjPpj5DHuqlebTp4TI=
+github.com/knqyf263/fanal v0.0.0-20190516002914-a1530cdb9a80 h1:6cXQOaOGU33P+22DKh6n7Pp+Tb5DLPwvqlJ7De34ZMg=
+github.com/knqyf263/fanal v0.0.0-20190516002914-a1530cdb9a80/go.mod h1:NQxdeR5taRqHUw9B2zkPCh/klHFaFb13j8QcQ6yxg60=
 github.com/knqyf263/go-deb-version v0.0.0-20170509080151-9865fe14d09b h1:DiDMmSwuY27PJxA2Gs0+uI/bQ/ehKARaGXRdlp+wFis=
 github.com/knqyf263/go-deb-version v0.0.0-20170509080151-9865fe14d09b/go.mod h1:o8sgWoz3JADecfc/cTYD92/Et1yMqMy0utV1z+VaZao=
 github.com/knqyf263/go-dep-parser v0.0.0-20190511063217-d5d543bfc261 h1:RPgPsbEsYj6LuOjZnKl2DvbfodNWRuWKZfWJkrD7l8s=
 github.com/knqyf263/go-dep-parser v0.0.0-20190511063217-d5d543bfc261/go.mod h1:gSiqSkOFPstUZu/qZ4wnNJS69PtQQnPl397vxKHJ5mQ=
+github.com/knqyf263/go-dep-parser v0.0.0-20190515172517-b8305876c9c2 h1:bQGj8WH6X4czC2FlkgUKKFq2xPnJovzf61T4Yl9sVZs=
+github.com/knqyf263/go-dep-parser v0.0.0-20190515172517-b8305876c9c2/go.mod h1:gSiqSkOFPstUZu/qZ4wnNJS69PtQQnPl397vxKHJ5mQ=
 github.com/knqyf263/go-rpm-version v0.0.0-20170716094938-74609b86c936 h1:HDjRqotkViMNcGMGicb7cgxklx8OwnjtCBmyWEqrRvM=
 github.com/knqyf263/go-rpm-version v0.0.0-20170716094938-74609b86c936/go.mod h1:i4sF0l1fFnY1aiw08QQSwVAFxHEm311Me3WsU/X7nL0=
 github.com/knqyf263/go-rpmdb v0.0.0-20190501070121-10a1c42a10dc/go.mod h1:MrSSvdMpTSymaQWk1yFr9sxFSyQmKMj6jkbvGrchBV8=

--- a/go.sum
+++ b/go.sum
@@ -114,14 +114,10 @@ github.com/kevinburke/ssh_config v0.0.0-20180830205328-81db2a75821e h1:RgQk53JHp
 github.com/kevinburke/ssh_config v0.0.0-20180830205328-81db2a75821e/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/knqyf263/berkeleydb v0.0.0-20190501065933-fafe01fb9662/go.mod h1:bu1CcN4tUtoRcI/B/RFHhxMNKFHVq/c3SV+UTyduoXg=
-github.com/knqyf263/fanal v0.0.0-20190514052804-ca40e6cb0e1a h1:2zG9YY77/Nv+dMcAA3EzRwoUWP0cWmQIuAumhEYZtNQ=
-github.com/knqyf263/fanal v0.0.0-20190514052804-ca40e6cb0e1a/go.mod h1:HTp1oNm2dPtIooJCspQHukx37GjPpj5DHuqlebTp4TI=
 github.com/knqyf263/fanal v0.0.0-20190516002914-a1530cdb9a80 h1:6cXQOaOGU33P+22DKh6n7Pp+Tb5DLPwvqlJ7De34ZMg=
 github.com/knqyf263/fanal v0.0.0-20190516002914-a1530cdb9a80/go.mod h1:NQxdeR5taRqHUw9B2zkPCh/klHFaFb13j8QcQ6yxg60=
 github.com/knqyf263/go-deb-version v0.0.0-20170509080151-9865fe14d09b h1:DiDMmSwuY27PJxA2Gs0+uI/bQ/ehKARaGXRdlp+wFis=
 github.com/knqyf263/go-deb-version v0.0.0-20170509080151-9865fe14d09b/go.mod h1:o8sgWoz3JADecfc/cTYD92/Et1yMqMy0utV1z+VaZao=
-github.com/knqyf263/go-dep-parser v0.0.0-20190511063217-d5d543bfc261 h1:RPgPsbEsYj6LuOjZnKl2DvbfodNWRuWKZfWJkrD7l8s=
-github.com/knqyf263/go-dep-parser v0.0.0-20190511063217-d5d543bfc261/go.mod h1:gSiqSkOFPstUZu/qZ4wnNJS69PtQQnPl397vxKHJ5mQ=
 github.com/knqyf263/go-dep-parser v0.0.0-20190515172517-b8305876c9c2 h1:bQGj8WH6X4czC2FlkgUKKFq2xPnJovzf61T4Yl9sVZs=
 github.com/knqyf263/go-dep-parser v0.0.0-20190515172517-b8305876c9c2/go.mod h1:gSiqSkOFPstUZu/qZ4wnNJS69PtQQnPl397vxKHJ5mQ=
 github.com/knqyf263/go-rpm-version v0.0.0-20170716094938-74609b86c936 h1:HDjRqotkViMNcGMGicb7cgxklx8OwnjtCBmyWEqrRvM=

--- a/pkg/scanner/library/node/advisory.go
+++ b/pkg/scanner/library/node/advisory.go
@@ -1,4 +1,4 @@
-package npm
+package node
 
 import (
 	"encoding/json"

--- a/pkg/scanner/library/scan.go
+++ b/pkg/scanner/library/scan.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/knqyf263/fanal/analyzer/library/composer"
 	_ "github.com/knqyf263/fanal/analyzer/library/npm"
 	_ "github.com/knqyf263/fanal/analyzer/library/pipenv"
+	_ "github.com/knqyf263/fanal/analyzer/library/yarn"
 	"github.com/knqyf263/fanal/extractor"
 	ptypes "github.com/knqyf263/go-dep-parser/pkg/types"
 	"github.com/knqyf263/go-version"
@@ -19,7 +20,7 @@ import (
 	"github.com/knqyf263/trivy/pkg/scanner/library/bundler"
 	"github.com/knqyf263/trivy/pkg/scanner/library/cargo"
 	"github.com/knqyf263/trivy/pkg/scanner/library/composer"
-	"github.com/knqyf263/trivy/pkg/scanner/library/npm"
+	"github.com/knqyf263/trivy/pkg/scanner/library/node"
 	"github.com/knqyf263/trivy/pkg/scanner/library/pipenv"
 	"golang.org/x/xerrors"
 )
@@ -41,7 +42,9 @@ func NewScanner(filename string) Scanner {
 	case "composer.lock":
 		scanner = composer.NewScanner()
 	case "package-lock.json":
-		scanner = npm.NewScanner()
+		scanner = node.NewScanner(node.ScannerTypeNpm)
+	case "yarn.lock":
+		scanner = node.NewScanner(node.ScannerTypeYarn)
 	case "Pipfile.lock":
 		scanner = pipenv.NewScanner()
 	default:


### PR DESCRIPTION
- merge npm and yarn to node scanner
- support yarn.lock

```
2019-05-16T10:14:06.623+0900    INFO    Resetting DB...
2019-05-16T10:14:06.646+0900    WARN    You should avoid using the :latest tag as it is cached. You need to specify '--clear-cache' option when :latest image is changed
2019-05-16T10:14:09.255+0900    INFO    Detecting Alpine vulnerabilities...
2019-05-16T10:14:09.256+0900    INFO    Updating yarn Security DB...
2019-05-16T10:14:11.209+0900    INFO    Detecting yarn vulnerabilities...

asia.gcr.io/bizvoice-app-stg/api-streaming:latest (alpine 3.9.0)
================================================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


yarn.lock
=========
Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

+------------+------------------+----------+-------------------+---------------+-------------------+
|  LIBRARY   | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |       TITLE       |
+------------+------------------+----------+-------------------+---------------+-------------------+
| protobufjs | NSWG-ECO-400     | MEDIUM   | 5.0.3             | >=6.8.6       | Denial of Service |
+------------+------------------+----------+-------------------+---------------+-------------------+
```