### PR TITLE
Allow user specified cache directory

### DIFF
--- a/cmd/trivy/main.go
+++ b/cmd/trivy/main.go
@@ -93,6 +93,10 @@ OPTIONS:
 			Name:  "debug, d",
 			Usage: "debug mode",
 		},
+		cli.StringFlag{
+			Name: "cache-dir",
+			Usage: "cache directory",
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -16,10 +16,10 @@ import (
 
 var (
 	db    *bolt.DB
-	dbDir = filepath.Join(utils.CacheDir(), "db")
 )
 
 func Init() (err error) {
+	dbDir := filepath.Join(utils.CacheDir(), "db")
 	if err = os.MkdirAll(dbDir, 0700); err != nil {
 		return xerrors.Errorf("failed to mkdir: %w", err)
 	}
@@ -34,6 +34,7 @@ func Init() (err error) {
 }
 
 func Reset() error {
+	dbDir := filepath.Join(utils.CacheDir(), "db")
 	if err := os.RemoveAll(dbDir); err != nil {
 		return xerrors.Errorf("failed to reset DB: %w", err)
 	}

--- a/pkg/run.go
+++ b/pkg/run.go
@@ -29,6 +29,12 @@ func Run(c *cli.Context) (err error) {
 	if err = log.InitLogger(debug); err != nil {
 		l.Fatal(err)
 	}
+
+	cacheDir := c.String("cache-dir")
+	if cacheDir != "" {
+		utils.SetCacheDir(cacheDir)
+	}
+
 	log.Logger.Debugf("cache dir:  %s", utils.CacheDir())
 
 	if c.Bool("reset") {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -12,13 +12,22 @@ import (
 	"golang.org/x/xerrors"
 )
 
+var cacheDir string
+
 func CacheDir() string {
-	cacheDir, err := os.UserCacheDir()
-	if err != nil {
-		cacheDir = os.TempDir()
+	if cacheDir == "" {
+		var err error
+		cacheDir, err = os.UserCacheDir()
+		if err != nil {
+			cacheDir = os.TempDir()
+		}
 	}
 	dir := filepath.Join(cacheDir, "trivy")
 	return dir
+}
+
+func SetCacheDir(cd string) {
+	cacheDir = cd
 }
 
 func FileWalk(root string, targetFiles map[string]struct{}, walkFn func(r io.Reader, path string) error) error {


### PR DESCRIPTION
The flag cache-dir allows users to specify the cache directory the
database is stored in.  If the flag value is not set, try to use the users cache directory or a temp directory.

Fixes #10 

Signed-off-by: Ken Herner <kherner@navistone.com>