### PR TITLE
Suggest putting the apt source in its own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ CODE_NAME: wheezy, jessie, stretch, buster, trusty, xenial, bionic
 ```
 $ sudo apt-get install apt-transport-https gnupg
 $ wget -qO - https://knqyf263.github.io/trivy-repo/deb/public.key | sudo apt-key add -
-$ echo deb https://knqyf263.github.io/trivy-repo/deb [CODE_NAME] main | sudo tee -a /etc/apt/sources.list
+$ echo deb https://knqyf263.github.io/trivy-repo/deb [CODE_NAME] main | sudo tee -a /etc/apt/sources.list.d/trivy.list
 $ sudo apt-get update
 $ sudo apt-get install trivy
 ```


### PR DESCRIPTION
So it is a bit cleaner and the main file is not that cluttered.