### PR TITLE
show scanned os.Family if unsupported

### DIFF
--- a/pkg/scanner/ospkg/scan.go
+++ b/pkg/scanner/ospkg/scan.go
@@ -41,7 +41,7 @@ func Scan(files extractor.FileMap) (string, string, []vulnerability.DetectedVuln
 	case fos.RedHat, fos.CentOS:
 		s = redhat.NewScanner()
 	default:
-		return "", "", nil, xerrors.New("unsupported os")
+		return "", "", nil, xerrors.Errorf("unsupported os : %s", os.Family)
 	}
 	pkgs, err := analyzer.GetPackages(files)
 	if err != nil {


### PR DESCRIPTION
show os.Family if an unsupported OS

```
FATAL   error in image scan: failed to scan image: unsupported os : fedora
```