### PR TITLE
Added --only-update option

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,9 +716,9 @@ Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)
 
 </details>
 
-### Only an update of you are specified distribution
+### Update only you are specified distributions
 
-By default, `Trivy` always updates vulnerability database of all distribution. Use the `--only-update` option if you want to update only specified destributions.
+By default, `Trivy` always updates vulnerability database of all distribution. Use the `--only-update` option if you want to update only specified distributions.
 
 ```
 $ trivy --only-update alpine,debian python:3.4-alpine3.9

--- a/README.md
+++ b/README.md
@@ -716,6 +716,37 @@ Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)
 
 </details>
 
+### Only an update of you are specified distribution
+
+By default, `Trivy` always updates vulnerability database of all distribution. Use the `--only-update` option if you want to update only specified destributions.
+
+```
+$ trivy --only-update alpine,debian python:3.4-alpine3.9
+$ trivy --only-update alpine python:3.4-alpine3.9
+```
+
+<details>
+<summary>Result</summary>
+
+```
+2019-05-21T19:37:06.301+0900    INFO    Updating vulnerability database...
+2019-05-21T19:37:07.793+0900    INFO    Updating alpine data...
+2019-05-21T19:37:08.127+0900    INFO    Detecting Alpine vulnerabilities...
+
+python:3.4-alpine3.9 (alpine 3.9.2)
+===================================
+Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)
+
++---------+------------------+----------+-------------------+---------------+--------------------------------+
+| LIBRARY | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |             TITLE              |
++---------+------------------+----------+-------------------+---------------+--------------------------------+
+| openssl | CVE-2019-1543    | MEDIUM   | 1.1.1a-r1         | 1.1.1b-r1     | openssl: ChaCha20-Poly1305     |
+|         |                  |          |                   |               | with long nonces               |
++---------+------------------+----------+-------------------+---------------+--------------------------------+
+```
+
+</details>
+
 ### Ignore unfixed vulnerabilities
 
 By default, `Trivy` also detects unpatched/unfixed vulnerabilities. This means you can't fix these vulnerabilities even if you update all packages.

--- a/cmd/trivy/main.go
+++ b/cmd/trivy/main.go
@@ -69,6 +69,10 @@ OPTIONS:
 			Name:  "skip-update",
 			Usage: "skip db update",
 		},
+		cli.StringFlag{
+			Name:  "only-update",
+			Usage: "update db only specified distribution (comma separated)",
+		},
 		cli.BoolFlag{
 			Name:  "reset",
 			Usage: "remove all caches and database",

--- a/pkg/run.go
+++ b/pkg/run.go
@@ -102,6 +102,7 @@ func Run(c *cli.Context) (err error) {
 	}
 	// this condition is already validated by skipUpdate && onlyUpdate != ""
 	if onlyUpdate != "" {
+		log.Logger.Warn("The --update-only option may cause the vulnerability details such as severity and title not to be displayed")
 		if err = vulnsrc.Update(strings.Split(onlyUpdate, ",")); err != nil {
 			return xerrors.Errorf("error in vulnerability DB update: %w", err)
 		}

--- a/pkg/run.go
+++ b/pkg/run.go
@@ -7,20 +7,15 @@ import (
 
 	"github.com/genuinetools/reg/registry"
 	"github.com/knqyf263/fanal/cache"
-
-	"github.com/knqyf263/trivy/pkg/utils"
-
-	"github.com/knqyf263/trivy/pkg/vulnsrc/vulnerability"
-
-	"github.com/knqyf263/trivy/pkg/report"
-	"github.com/knqyf263/trivy/pkg/scanner"
-	"github.com/knqyf263/trivy/pkg/vulnsrc"
-
-	"github.com/urfave/cli"
-	"golang.org/x/xerrors"
-
 	"github.com/knqyf263/trivy/pkg/db"
 	"github.com/knqyf263/trivy/pkg/log"
+	"github.com/knqyf263/trivy/pkg/report"
+	"github.com/knqyf263/trivy/pkg/scanner"
+	"github.com/knqyf263/trivy/pkg/utils"
+	"github.com/knqyf263/trivy/pkg/vulnsrc"
+	"github.com/knqyf263/trivy/pkg/vulnsrc/vulnerability"
+	"github.com/urfave/cli"
+	"golang.org/x/xerrors"
 )
 
 func Run(c *cli.Context) (err error) {
@@ -107,11 +102,11 @@ func Run(c *cli.Context) (err error) {
 	}
 	// this condition is already validated by skipUpdate && onlyUpdate != ""
 	if onlyUpdate != "" {
-		if err = vulnsrc.OnlyUpdate(strings.Split(onlyUpdate, ",")); err != nil {
+		if err = vulnsrc.Update(strings.Split(onlyUpdate, ",")); err != nil {
 			return xerrors.Errorf("error in vulnerability DB update: %w", err)
 		}
 	} else {
-		if err = vulnsrc.UpdateAll(); err != nil {
+		if err = vulnsrc.Update(vulnerability.DBNames); err != nil {
 			return xerrors.Errorf("error in vulnerability DB update: %w", err)
 		}
 	}

--- a/pkg/scanner/ospkg/alpine/alpine.go
+++ b/pkg/scanner/ospkg/alpine/alpine.go
@@ -3,17 +3,13 @@ package alpine
 import (
 	"strings"
 
-	"github.com/knqyf263/trivy/pkg/vulnsrc/vulnerability"
-
-	"golang.org/x/xerrors"
-
-	version "github.com/knqyf263/go-rpm-version"
-	"github.com/knqyf263/trivy/pkg/scanner/utils"
-
-	"github.com/knqyf263/trivy/pkg/vulnsrc/alpine"
-
 	"github.com/knqyf263/fanal/analyzer"
+	version "github.com/knqyf263/go-rpm-version"
 	"github.com/knqyf263/trivy/pkg/log"
+	"github.com/knqyf263/trivy/pkg/scanner/utils"
+	"github.com/knqyf263/trivy/pkg/vulnsrc/alpine"
+	"github.com/knqyf263/trivy/pkg/vulnsrc/vulnerability"
+	"golang.org/x/xerrors"
 )
 
 type Scanner struct{}

--- a/pkg/vulnsrc/vulnerability/const.go
+++ b/pkg/vulnsrc/vulnerability/const.go
@@ -17,3 +17,11 @@ const (
 	NodejsSecurityWg      = "nodejs-security-wg"
 	PythonSafetyDB        = "python-safety-db"
 )
+
+var DBNames = []string{
+	Nvd,
+	RedHat,
+	Debian,
+	DebianOVAL,
+	Ubuntu,
+}

--- a/pkg/vulnsrc/vulnsrc.go
+++ b/pkg/vulnsrc/vulnsrc.go
@@ -12,6 +12,7 @@ import (
 	"github.com/knqyf263/trivy/pkg/vulnsrc/nvd"
 	"github.com/knqyf263/trivy/pkg/vulnsrc/redhat"
 	"github.com/knqyf263/trivy/pkg/vulnsrc/ubuntu"
+	"github.com/knqyf263/trivy/pkg/vulnsrc/vulnerability"
 	"golang.org/x/xerrors"
 )
 
@@ -19,7 +20,18 @@ const (
 	repoURL = "https://github.com/knqyf263/vuln-list.git"
 )
 
-func Update() (err error) {
+type updateFunc func(dir string, updatedFiles map[string]struct{}) error
+
+var updateMap = map[string]updateFunc{
+	vulnerability.Nvd:        nvd.Update,
+	vulnerability.Alpine:     alpine.Update,
+	vulnerability.RedHat:     redhat.Update,
+	vulnerability.Debian:     debian.Update,
+	vulnerability.DebianOVAL: debianoval.Update,
+	vulnerability.Ubuntu:     ubuntu.Update,
+}
+
+func UpdateAll() (err error) {
 	log.Logger.Info("Updating vulnerability database...")
 
 	// Clone vuln-list repository
@@ -35,41 +47,49 @@ func Update() (err error) {
 		return nil
 	}
 
-	// Update NVD
-	log.Logger.Info("Updating NVD data...")
-	if err = nvd.Update(dir, updatedFiles); err != nil {
-		return xerrors.Errorf("error in NVD update: %w", err)
+	updateOrder := []string{
+		vulnerability.Nvd,
+		vulnerability.Alpine,
+		vulnerability.RedHat,
+		vulnerability.Debian,
+		vulnerability.DebianOVAL,
+		vulnerability.Ubuntu,
+	}
+	for _, distribution := range updateOrder {
+		updateFunc := updateMap[distribution]
+		log.Logger.Infof("Updating %s data...", distribution)
+		if err := updateFunc(dir, updatedFiles); err != nil {
+			return xerrors.Errorf("error in %s update: %w", distribution, err)
+		}
+	}
+	return nil
+}
+
+func OnlyUpdate(names []string) error {
+	log.Logger.Info("Updating vulnerability database...")
+
+	// Clone vuln-list repository
+	dir := filepath.Join(utils.CacheDir(), "vuln-list")
+	updatedFiles, err := git.CloneOrPull(repoURL, dir)
+	if err != nil {
+		return xerrors.Errorf("error in vulnsrc clone or pull: %w", err)
+	}
+	log.Logger.Debugf("total updated files: %d", len(updatedFiles))
+
+	// Only last_updated.json
+	if len(updatedFiles) <= 1 {
+		return nil
 	}
 
-	// Update Alpine OVAL
-	log.Logger.Info("Updating Alpine data...")
-	if err = alpine.Update(dir, updatedFiles); err != nil {
-		return xerrors.Errorf("error in Alpine OVAL update: %w", err)
+	for _, distribution := range names {
+		updateFunc, ok := updateMap[distribution]
+		if !ok {
+			return xerrors.Errorf("%s does not supported yet", distribution)
+		}
+		log.Logger.Infof("Updating %s data...", distribution)
+		if err := updateFunc(dir, updatedFiles); err != nil {
+			return xerrors.Errorf("error in %s update: %w", distribution, err)
+		}
 	}
-
-	// Update RedHat
-	log.Logger.Info("Updating RedHat data...")
-	if err = redhat.Update(dir, updatedFiles); err != nil {
-		return xerrors.Errorf("error in RedHat update: %w", err)
-	}
-
-	// Update Debian
-	log.Logger.Info("Updating Debian data...")
-	if err = debian.Update(dir, updatedFiles); err != nil {
-		return xerrors.Errorf("error in Debian update: %w", err)
-	}
-
-	// Update Debian OVAL
-	log.Logger.Info("Updating Debian OVAL data...")
-	if err = debianoval.Update(dir, updatedFiles); err != nil {
-		return xerrors.Errorf("error in Debian OVAL update: %w", err)
-	}
-
-	// Update Ubuntu
-	log.Logger.Info("Updating Ubuntu data...")
-	if err = ubuntu.Update(dir, updatedFiles); err != nil {
-		return xerrors.Errorf("error in Ubuntu update: %w", err)
-	}
-
 	return nil
 }

--- a/pkg/vulnsrc/vulnsrc.go
+++ b/pkg/vulnsrc/vulnsrc.go
@@ -31,41 +31,7 @@ var updateMap = map[string]updateFunc{
 	vulnerability.Ubuntu:     ubuntu.Update,
 }
 
-func UpdateAll() (err error) {
-	log.Logger.Info("Updating vulnerability database...")
-
-	// Clone vuln-list repository
-	dir := filepath.Join(utils.CacheDir(), "vuln-list")
-	updatedFiles, err := git.CloneOrPull(repoURL, dir)
-	if err != nil {
-		return xerrors.Errorf("error in vulnsrc clone or pull: %w", err)
-	}
-	log.Logger.Debugf("total updated files: %d", len(updatedFiles))
-
-	// Only last_updated.json
-	if len(updatedFiles) <= 1 {
-		return nil
-	}
-
-	updateOrder := []string{
-		vulnerability.Nvd,
-		vulnerability.Alpine,
-		vulnerability.RedHat,
-		vulnerability.Debian,
-		vulnerability.DebianOVAL,
-		vulnerability.Ubuntu,
-	}
-	for _, distribution := range updateOrder {
-		updateFunc := updateMap[distribution]
-		log.Logger.Infof("Updating %s data...", distribution)
-		if err := updateFunc(dir, updatedFiles); err != nil {
-			return xerrors.Errorf("error in %s update: %w", distribution, err)
-		}
-	}
-	return nil
-}
-
-func OnlyUpdate(names []string) error {
+func Update(names []string) error {
 	log.Logger.Info("Updating vulnerability database...")
 
 	// Clone vuln-list repository


### PR DESCRIPTION
## What

Added `--only-update` option. use this option, we can update vulnerability database only that we are specified distributions.

## Why

If we are creating an docker image based on one distribution (for example, use only alpine image), it is too much to update all DBs. therefore we necessary to wait to update for long time.