### PR TITLE
feat: add --depth option to git clone

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -92,7 +92,7 @@ func clone(url, repoPath string) error {
 }
 
 func cloneByOSCommand(url, repoPath string) error {
-	commandAndArgs := []string{"clone", url, repoPath}
+	commandAndArgs := []string{"clone", "--depth=1", url, repoPath}
 	_, err := utils.Exec("git", commandAndArgs)
 	if err != nil {
 		return xerrors.Errorf("error in git clone: %w", err)


### PR DESCRIPTION
add --depth option to git clone.

before:
```
$ time git clone https://github.com/knqyf263/vuln-list
Cloning into 'vuln-list'...
remote: Enumerating objects: 32220, done.
remote: Counting objects: 100% (32220/32220), done.
remote: Compressing objects: 100% (20546/20546), done.
remote: Total 505602 (delta 29307), reused 12089 (delta 11664), pack-reused 473382
Receiving objects: 100% (505602/505602), 183.02 MiB | 2.00 MiB/s, done.
Resolving deltas: 100% (476710/476710), done.
Checking out files: 100% (270908/270908), done.
git clone https://github.com/knqyf263/vuln-list  38.15s user 59.75s system 46% cpu 3:29.36 total
```

after:
```
$ time git clone --depth=1 https://github.com/knqyf263/vuln-list
Cloning into 'vuln-list'...
remote: Enumerating objects: 275059, done.
remote: Counting objects: 100% (275059/275059), done.
remote: Compressing objects: 100% (89333/89333), done.
remote: Total 275059 (delta 236398), reused 205815 (delta 183887), pack-reused 0
Receiving objects: 100% (275059/275059), 151.76 MiB | 4.75 MiB/s, done.
Resolving deltas: 100% (236398/236398), done.
Checking out files: 100% (270908/270908), done.
git clone --depth=1 https://github.com/knqyf263/vuln-list  30.76s user 44.66s system 61% cpu 2:02.48 total
```