### PR TITLE
Simpler Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ $ sudo dpkg -i trivy_0.0.15_Linux-64bit.deb
 You can use homebrew on Mac OS.
 
 ```
-$ brew tap knqyf263/trivy
 $ brew install knqyf263/trivy/trivy
 ```
 


### PR DESCRIPTION
You don't need to tap a repo to install from it with Homebrew it seems. Homebrew will automatically tap it with `brew install`:

```
❯ brew install knqyf263/trivy/trivy
Updating Homebrew...
....
Cloning into '/usr/local/Homebrew/Library/Taps/knqyf263/homebrew-trivy'...
remote: Enumerating objects: 3, done.
remote: Counting objects: 100% (3/3), done.
remote: Compressing objects: 100% (2/2), done.
remote: Total 3 (delta 0), reused 0 (delta 0), pack-reused 0
Unpacking objects: 100% (3/3), done.
Tapped 1 formula (27 files, 23.5KB).
==> Installing trivy from knqyf263/trivy
```