### PR TITLE
auth for private docker registry from ENV vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -983,12 +983,12 @@ export TRIVY_PASSWORD={DOCKERHUB_PASSWORD}
 
 ### Amazon ECR (Elastic Container Registry)
 
-Trivy use AWS SDK. You don't need to install `aws` CLI tool.
+Trivy uses AWS SDK. You don't need to install `aws` CLI tool.
 You can use [AWS CLI's ENV Vars](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).
 
 ### GCR (Google Container Registry)
 
-Trivy use Google Cloud SDK. You don't need to install `gcloud` command.
+Trivy uses Google Cloud SDK. You don't need to install `gcloud` command.
 
 If you want to use target project's repository, you can settle via `GOOGLE_APPLICATION_CREDENTIAL`. 
 ```bash

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ See [Comparison with other scanners](#comparison-with-other-scanners) for detail
 - [Continuous Integration (CI)](#continuous-integration-ci)
   - [Travis CI](#travis-ci)
   - [Circle CI](#circle-ci)
+  - [Authorization for Private Docker Registry](#authorization-for-private-docker-registry)
 - [Vulnerability Detection](#vulnerability-detection)
   - [OS Packages](#os-packages)
   - [Application Dependencies](#application-dependencies)
@@ -961,7 +962,7 @@ workflows:
 Example: https://circleci.com/gh/knqyf263/trivy-ci-test  
 Repository: https://github.com/knqyf263/trivy-ci-test
 
-## Authorization for Private Docker Registry without Docker
+## Authorization for Private Docker Registry
 
 Trivy can download images from private registry, without installing `Docker` and any 3rd party tools.
 That's because it's easy to run in a CI process.
@@ -982,12 +983,12 @@ export TRIVY_PASSWORD={DOCKERHUB_PASSWORD}
 
 ### Amazon ECR (Elastic Container Registry)
 
-Trivi use AWS SDK. You don't need to install `aws` CLI tool.
+Trivy use AWS SDK. You don't need to install `aws` CLI tool.
 You can use [AWS CLI's ENV Vars](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).
 
 ### GCR (Google Container Registry)
 
-Trivi use Google Cloud SDK. You don't need to install `gcloud` command.
+Trivy use Google Cloud SDK. You don't need to install `gcloud` command.
 
 If you want to use target project's repository, you can settle via `GOOGLE_APPLICATION_CREDENTIAL`. 
 ```bash

--- a/README.md
+++ b/README.md
@@ -961,6 +961,61 @@ workflows:
 Example: https://circleci.com/gh/knqyf263/trivy-ci-test  
 Repository: https://github.com/knqyf263/trivy-ci-test
 
+## Authorization for Private Docker Registry without Docker
+
+Trivy can download image without installing `Docker`, and fetch from private repositories without any 3rd party tools.
+
+That's because it's easy to run in a CI process.
+I hardly recommend using it in your local machine to you.
+You only to set ENV vars on a CI tool.
+
+### Dockerhub
+
+Dockerhub needs `TRIVY_AUTH_URL`, `TRIVY_USERNAME` and `TRIVY_PASSWORD`.
+You don't need to set ENV vars when download from public repository.
+
+```bash
+export TRIVY_AUTH_URL=https://registry.hub.docker.com
+export TRIVY_USERNAME={DOCKERHUB_USERNAME}
+export TRIVY_PASSWORD={DOCKERHUB_PASSWORD}
+```
+
+### Amazon ECR (Elastic Container Registry)
+
+Amazon ECR needs `TRIVY_AWS_ACCESS`, `TRIVY_AWS_SECRET` and `TRIVY_AWS_REGION`.
+You don't need to install `aws` CLI tool.
+
+```bash
+# must set TRIVY_USERNAME empty char
+export TRIVY_USERNAME=
+export TRIVY_AWS_ACCESS={AWS_ACCESS_KEY}
+export TRIVY_AWS_SECRET={AWS_SECRET_KEY}
+export TRIVY_AWS_REGION={AWS_REGION}
+```
+
+### GCR (Google Container Registry)
+
+GCR needs `GOOGLE_APPLICATION_CREDENTIALS` and target project's credential file.
+You don't need to install `gcloud` command.
+
+```bash
+# must set TRIVY_USERNAME empty char
+export TRIVY_USERNAME=
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credential.json
+```
+
+### Self Hosted Registry (BasicAuth)
+
+BasicAuth server needs `TRIVY_USERNAME` and `TRIVY_PASSWORD`.
+
+```bash
+export TRIVY_USERNAME={USERNAME}
+export TRIVY_PASSWORD={PASSWORD}
+
+# if you want to use 80 port, use NonSSL
+export TRIVY_NON_SSL=true
+```
+
 # Vulnerability Detection
 
 ## OS Packages

--- a/README.md
+++ b/README.md
@@ -969,9 +969,9 @@ That's because it's easy to run in a CI process.
 All you have to do is install `Trivy` and set ENV vars.
 But, I can't recommend using ENV vars in your local machine to you.
 
-### Dockerhub
+### Docker Hub
 
-Dockerhub needs `TRIVY_AUTH_URL`, `TRIVY_USERNAME` and `TRIVY_PASSWORD`.
+Docker Hub needs `TRIVY_AUTH_URL`, `TRIVY_USERNAME` and `TRIVY_PASSWORD`.
 You don't need to set ENV vars when download from public repository.
 
 ```bash
@@ -982,25 +982,16 @@ export TRIVY_PASSWORD={DOCKERHUB_PASSWORD}
 
 ### Amazon ECR (Elastic Container Registry)
 
-Amazon ECR needs `TRIVY_AWS_ACCESS`, `TRIVY_AWS_SECRET` and `TRIVY_AWS_REGION`.
-You don't need to install `aws` CLI tool.
-
-```bash
-# must set TRIVY_USERNAME empty char
-export TRIVY_USERNAME=
-export TRIVY_AWS_ACCESS={AWS_ACCESS_KEY}
-export TRIVY_AWS_SECRET={AWS_SECRET_KEY}
-export TRIVY_AWS_REGION={AWS_REGION}
-```
+Trivi use AWS SDK. You don't need to install `aws` CLI tool.
+You can use [AWS CLI's ENV Vars](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).
 
 ### GCR (Google Container Registry)
 
-GCR needs `GOOGLE_APPLICATION_CREDENTIALS` and target project's credential file.
-You don't need to install `gcloud` command.
+Trivi use Google Cloud SDK. You don't need to install `gcloud` command.
 
+If you want to use target project's repository, you can settle via `GOOGLE_APPLICATION_CREDENTIAL`. 
 ```bash
 # must set TRIVY_USERNAME empty char
-export TRIVY_USERNAME=
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/credential.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -963,11 +963,11 @@ Repository: https://github.com/knqyf263/trivy-ci-test
 
 ## Authorization for Private Docker Registry without Docker
 
-Trivy can download image without installing `Docker`, and fetch from private repositories without any 3rd party tools.
-
+Trivy can download images from private registry, without installing `Docker` and any 3rd party tools.
 That's because it's easy to run in a CI process.
-I hardly recommend using it in your local machine to you.
-You only to set ENV vars on a CI tool.
+
+All you have to do is install `Trivy` and set ENV vars.
+But, I can't recommend using ENV vars in your local machine to you.
 
 ### Dockerhub
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/briandowns/spinner v0.0.0-20190319032542-ac46072a5a91
+	github.com/caarlos0/env/v6 v6.0.0
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/etcd-io/bbolt v1.3.2
 	github.com/fatih/color v1.7.0
@@ -20,7 +21,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.1
-	github.com/stretchr/testify v1.3.0 // indirect
 	github.com/urfave/cli v1.20.0
 	github.com/xanzy/ssh-agent v0.2.1 // indirect
 	go.etcd.io/bbolt v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLM
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/briandowns/spinner v0.0.0-20190319032542-ac46072a5a91 h1:GMmnK0dvr0Sf0gx3DvTbln0c8DE07B7sPVD9dgHOqo4=
 github.com/briandowns/spinner v0.0.0-20190319032542-ac46072a5a91/go.mod h1:hw/JEQBIE+c/BLI4aKM8UU8v+ZqrD3h7HC27kKt8JQU=
+github.com/caarlos0/env/v6 v6.0.0 h1:NZt6FAoB8ieKO5lEwRdwCzYxWFx7ZYF2R7UcoyaWtyc=
+github.com/caarlos0/env/v6 v6.0.0/go.mod h1:+wdyOmtjoZIW2GJOc2OYa5NoOFuWD/bIpWqm30NgtRk=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/containerd/continuity v0.0.0-20180921161001-7f53d412b9eb h1:qSMRxG547z/BgQmyVyADxaMADQXVAD9uleP2sQeClbo=
 github.com/containerd/continuity v0.0.0-20180921161001-7f53d412b9eb/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=

--- a/pkg/scanner/scan.go
+++ b/pkg/scanner/scan.go
@@ -10,6 +10,7 @@ import (
 	"github.com/knqyf263/fanal/extractor"
 	"github.com/knqyf263/trivy/pkg/scanner/library"
 	"github.com/knqyf263/trivy/pkg/scanner/ospkg"
+	"github.com/knqyf263/trivy/pkg/types"
 	"github.com/knqyf263/trivy/pkg/vulnsrc/vulnerability"
 	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/xerrors"
@@ -24,7 +25,11 @@ func ScanImage(imageName, filePath string) (map[string][]vulnerability.DetectedV
 	var files extractor.FileMap
 	if imageName != "" {
 		target = imageName
-		files, err = analyzer.Analyze(ctx, imageName)
+		dockerOption, err := types.GetDockerOption()
+		if err != nil {
+			return nil, xerrors.Errorf("failed to get docker option: %w", err)
+		}
+		files, err = analyzer.Analyze(ctx, imageName, dockerOption)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to analyze image: %w", err)
 		}

--- a/pkg/types/dockerConf.go
+++ b/pkg/types/dockerConf.go
@@ -1,0 +1,40 @@
+package types
+
+import (
+	"time"
+
+	"github.com/caarlos0/env/v6"
+	"github.com/knqyf263/fanal/types"
+)
+
+type DockerConfig struct {
+	AuthURL      string        `env:"TRIVY_AUTH_URL"`
+	UserName     string        `env:"TRIVY_USERNAME"`
+	Password     string        `env:"TRIVY_PASSWORD"`
+	GcpCredPath  string        `env:"TRIVY_GCP_CREDENTIAL"`
+	AwsAccessKey string        `env:"TRIVY_AWS_ACCESS"`
+	AwsSecretKey string        `env:"TRIVY_AWS_SECRET"`
+	AwsRegion    string        `env:"TRIVY_AWS_REGION"`
+	Timeout      time.Duration `env:"TRIVY_TIMEOUT_SEC" envDefault:"60s"`
+	Insecure     bool          `env:"TRIVY_INSECURE" envDefault:"true"`
+	NonSSL       bool          `env:"TRIVY_NON_SSL" envDefault:"false"`
+}
+
+func GetDockerOption() (types.DockerOption, error) {
+	cfg := DockerConfig{}
+	if err := env.Parse(&cfg); err != nil {
+		return types.DockerOption{}, nil
+	}
+	return types.DockerOption{
+		AuthURL:      cfg.AuthURL,
+		UserName:     cfg.UserName,
+		Password:     cfg.Password,
+		GcpCredPath:  cfg.GcpCredPath,
+		AwsAccessKey: cfg.AwsAccessKey,
+		AwsSecretKey: cfg.AwsSecretKey,
+		AwsRegion:    cfg.AwsRegion,
+		Timeout:      cfg.Timeout,
+		Insecure:     cfg.Insecure,
+		NonSSL:       cfg.NonSSL,
+	}, nil
+}

--- a/pkg/types/dockerConf.go
+++ b/pkg/types/dockerConf.go
@@ -8,33 +8,25 @@ import (
 )
 
 type DockerConfig struct {
-	AuthURL      string        `env:"TRIVY_AUTH_URL"`
-	UserName     string        `env:"TRIVY_USERNAME"`
-	Password     string        `env:"TRIVY_PASSWORD"`
-	GcpCredPath  string        `env:"TRIVY_GCP_CREDENTIAL"`
-	AwsAccessKey string        `env:"TRIVY_AWS_ACCESS"`
-	AwsSecretKey string        `env:"TRIVY_AWS_SECRET"`
-	AwsRegion    string        `env:"TRIVY_AWS_REGION"`
-	Timeout      time.Duration `env:"TRIVY_TIMEOUT_SEC" envDefault:"60s"`
-	Insecure     bool          `env:"TRIVY_INSECURE" envDefault:"true"`
-	NonSSL       bool          `env:"TRIVY_NON_SSL" envDefault:"false"`
+	AuthURL  string        `env:"TRIVY_AUTH_URL"`
+	UserName string        `env:"TRIVY_USERNAME"`
+	Password string        `env:"TRIVY_PASSWORD"`
+	Timeout  time.Duration `env:"TRIVY_TIMEOUT_SEC" envDefault:"60s"`
+	Insecure bool          `env:"TRIVY_INSECURE" envDefault:"true"`
+	NonSSL   bool          `env:"TRIVY_NON_SSL" envDefault:"false"`
 }
 
 func GetDockerOption() (types.DockerOption, error) {
 	cfg := DockerConfig{}
 	if err := env.Parse(&cfg); err != nil {
-		return types.DockerOption{}, nil
+		return types.DockerOption{}, err
 	}
 	return types.DockerOption{
-		AuthURL:      cfg.AuthURL,
-		UserName:     cfg.UserName,
-		Password:     cfg.Password,
-		GcpCredPath:  cfg.GcpCredPath,
-		AwsAccessKey: cfg.AwsAccessKey,
-		AwsSecretKey: cfg.AwsSecretKey,
-		AwsRegion:    cfg.AwsRegion,
-		Timeout:      cfg.Timeout,
-		Insecure:     cfg.Insecure,
-		NonSSL:       cfg.NonSSL,
+		AuthURL:  cfg.AuthURL,
+		UserName: cfg.UserName,
+		Password: cfg.Password,
+		Timeout:  cfg.Timeout,
+		Insecure: cfg.Insecure,
+		NonSSL:   cfg.NonSSL,
 	}, nil
 }


### PR DESCRIPTION
This feature for CI jobs.

https://github.com/knqyf263/trivy/issues/45

- self-hosted registry test

```
$ docker run --rm --entrypoint htpasswd registry:latest -Bbn hoge hoge > /path/to/auth/htpasswd
$ docker run -d -p 80:80 -e REGISTRY_HTTP_ADDR=0.0.0.0:80 \
   -e REGISTRY_AUTH=htpasswd \
   -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" \
   -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
   -v /path/to/auth:/auth registry:latest

$ docker login localhost
Username: hoge
Password
```