### PR TITLE
Fix debug log

### DIFF
--- a/pkg/scanner/ospkg/debian/debian.go
+++ b/pkg/scanner/ospkg/debian/debian.go
@@ -30,7 +30,7 @@ func (s *Scanner) Detect(osVer string, pkgs []analyzer.Package) ([]vulnerability
 		osVer = osVer[:strings.Index(osVer, ".")]
 	}
 	log.Logger.Debugf("debian: os version: %s", osVer)
-	log.Logger.Debugf("debian: the number of packages: %s", len(pkgs))
+	log.Logger.Debugf("debian: the number of packages: %d", len(pkgs))
 
 	var vulns []vulnerability.DetectedVulnerability
 	for _, pkg := range pkgs {

--- a/pkg/scanner/ospkg/redhat/redhat.go
+++ b/pkg/scanner/ospkg/redhat/redhat.go
@@ -24,7 +24,7 @@ func (s *Scanner) Detect(osVer string, pkgs []analyzer.Package) ([]vulnerability
 		osVer = osVer[:strings.Index(osVer, ".")]
 	}
 	log.Logger.Debugf("redhat: os version: %s", osVer)
-	log.Logger.Debugf("redhat: the number of packages: %s", len(pkgs))
+	log.Logger.Debugf("redhat: the number of packages: %d", len(pkgs))
 
 	var vulns []vulnerability.DetectedVulnerability
 	for _, pkg := range pkgs {

--- a/pkg/scanner/ospkg/ubuntu/ubuntu.go
+++ b/pkg/scanner/ospkg/ubuntu/ubuntu.go
@@ -20,7 +20,7 @@ func NewScanner() *Scanner {
 func (s *Scanner) Detect(osVer string, pkgs []analyzer.Package) ([]vulnerability.DetectedVulnerability, error) {
 	log.Logger.Info("Detecting Ubuntu vulnerabilities...")
 	log.Logger.Debugf("ubuntu: os version: %s", osVer)
-	log.Logger.Debugf("ubuntu: the number of packages: %s", len(pkgs))
+	log.Logger.Debugf("ubuntu: the number of packages: %d", len(pkgs))
 
 	var vulns []vulnerability.DetectedVulnerability
 	for _, pkg := range pkgs {


### PR DESCRIPTION
```
09:18 $ trivy -f json -o scan.json -debug jcowey/vs-coder
2019-05-31T09:21:40.852+0100	DEBUG	cache dir:  /Users/jcowey/Library/Caches/trivy
2019-05-31T09:21:40.852+0100	DEBUG	db path: /Users/jcowey/Library/Caches/trivy/db/trivy.db
2019-05-31T09:21:40.861+0100	INFO	Updating vulnerability database...
2019-05-31T09:21:40.861+0100	DEBUG	git pull
2019-05-31T09:21:41.671+0100	DEBUG	total updated files: 1
2019-05-31T09:21:41.709+0100	WARN	You should avoid using the :latest tag as it is cached. You need to specify '--clear-cache' option when :latest image is changed
2019-05-31T09:21:51.016+0100	DEBUG	OS family: ubuntu, OS version: 18.04
2019-05-31T09:21:51.018+0100	DEBUG	the number of packages: 176
2019-05-31T09:21:51.018+0100	DEBUG	the number of packages from commands: 0
2019-05-31T09:21:51.018+0100	DEBUG	the number of packages: 176
2019-05-31T09:21:51.018+0100	INFO	Detecting Ubuntu vulnerabilities...
2019-05-31T09:21:51.018+0100	DEBUG	ubuntu: os version: 18.04
2019-05-31T09:21:51.018+0100	DEBUG	ubuntu: the number of packages: %!s(int=176)
```

Fixed debug log format.

`ubuntu: the number of packages: %!s(int=176)`