### PR TITLE
Add code snippet reminder on how to print distribution codename

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Replace `[CODE_NAME]` with your code name
 
 CODE_NAME: wheezy, jessie, stretch, buster, trusty, xenial, bionic
 
+`$ lsb_release -c`
+
 ```
 $ sudo apt-get install apt-transport-https gnupg
 $ wget -qO - https://knqyf263.github.io/trivy-repo/deb/public.key | sudo apt-key add -


### PR DESCRIPTION
Added a `lsb_release -c` to [Installation](https://github.com/akerge/trivy#debianubuntu).