### PR TITLE
[docker] Compress binary using upx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM golang:1.12-alpine AS builder
 ADD go.mod go.sum /app/
 WORKDIR /app/
-RUN apk --no-cache add git
+RUN apk --no-cache add git upx
 RUN go mod download
 ADD . /app/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=$(git describe --tags --abbrev=0)" -a -o /trivy cmd/trivy/main.go
+RUN upx --lzma --best /trivy
 
 FROM alpine:3.9
 RUN apk --no-cache add ca-certificates git


### PR DESCRIPTION
lzma looks better than the default compression algorithm

```
Step 8/13 : RUN upx --lzma --best /trivy
 ---> Running in 1f23fb026681
                       Ultimate Packer for eXecutables
                          Copyright (C) 1996 - 2018
UPX 3.95        Markus Oberhumer, Laszlo Molnar & John Reiser   Aug 26th 2018

        File size         Ratio      Format      Name
   --------------------   ------   -----------   -----------
  26868298 ->  10301860   38.34%   linux/amd64   trivy

Packed 1 file.
```

close #95