### PR TITLE
fix: test [backport: v0.51]

### DIFF
--- a/cmd/trivy/main.go
+++ b/cmd/trivy/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 
 	"golang.org/x/xerrors"
@@ -16,6 +17,7 @@ import (
 )
 
 func main() {
+	fmt.Println("test")
 	if err := run(); err != nil {
 		var exitError *types.ExitError
 		if errors.As(err, &exitError) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `v0.51`:
 - [fix: test (#38)](https://github.com/knqyf263/trivy/pull/38)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)