### PR TITLE
fix: test [backport: release/v0.53]

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,4 +148,8 @@ Please ensure to abide by our [Code of Conduct][code-of-conduct] during all inte
 [aquasec]: https://aquasec.com
 [oss]: https://www.aquasec.com/products/open-source-projects/
 [discussions]: https://github.com/aquasecurity/trivy/discussions
+<<<<<<< HEAD
 conflict
+=======
+test
+>>>>>>> 98c203700 (fix: test (#55))

--- a/README.md
+++ b/README.md
@@ -148,3 +148,4 @@ Please ensure to abide by our [Code of Conduct][code-of-conduct] during all inte
 [aquasec]: https://aquasec.com
 [oss]: https://www.aquasec.com/products/open-source-projects/
 [discussions]: https://github.com/aquasecurity/trivy/discussions
+conflict

--- a/docs/docs/coverage/language/dart.md
+++ b/docs/docs/coverage/language/dart.md
@@ -4,9 +4,9 @@ Trivy supports [Dart][dart].
 
 The following scanners are supported.
 
-| Package manager         | SBOM  | Vulnerability | License |
-|-------------------------| :---: | :-----------: |:-------:|
-| [Dart][dart-repository] |   ✓   |       ✓       |    -    |
+| Package manager         | SBOM | Vulnerability | License |
+|-------------------------|:----:|:-------------:|:-------:|
+| [Dart][dart-repository] |  ✓   |       ✓       |    -    |
 
 The following table provides an outline of the features Trivy offers.
 
@@ -21,6 +21,24 @@ In order to detect dependencies, Trivy searches for `pubspec.lock`.
 Trivy marks indirect dependencies, but `pubspec.lock` file doesn't have options to separate root and dev transitive dependencies.
 So Trivy includes all dependencies in report.
 
+### SDK dependencies
+Dart uses version `0.0.0` for SDK dependencies (e.g. Flutter). It is not possible to accurately determine the versions of these dependencies.
+
+Therefore, we use the first version of the constraint for the SDK.
+
+For example in this case the version of `flutter` should be `3.3.0`:
+```yaml
+flutter:
+  dependency: "direct main"
+  description: flutter
+  source: sdk
+  version: "0.0.0"
+sdks:
+  dart: ">=2.18.0 <3.0.0"
+  flutter: "^3.3.0"
+```
+
+### Dependency tree
 To build `dependency tree` Trivy parses [cache directory][cache-directory]. Currently supported default directories and `PUB_CACHE` environment (absolute path only).
 !!! note
     Make sure the cache directory contains all the dependencies installed in your application. To download missing dependencies, use `dart pub get` command.     

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce
 	github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798
 	github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46
-	github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492
+	github.com/aquasecurity/go-version v0.0.0-20240603093900-cf8a8d29271d
 	github.com/aquasecurity/loading v0.0.5
 	github.com/aquasecurity/table v1.8.0
 	github.com/aquasecurity/testdocker v0.0.0-20240419073403-90bd43849334

--- a/go.sum
+++ b/go.sum
@@ -760,8 +760,9 @@ github.com/aquasecurity/go-npm-version v0.0.0-20201110091526-0b796d180798/go.mod
 github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46 h1:vmXNl+HDfqqXgr0uY1UgK1GAhps8nbAAtqHNBcgyf+4=
 github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46/go.mod h1:olhPNdiiAAMiSujemd1O/sc6GcyePr23f/6uGKtthNg=
 github.com/aquasecurity/go-version v0.0.0-20201107203531-5e48ac5d022a/go.mod h1:9Beu8XsUNNfzml7WBf3QmyPToP1wm1Gj/Vc5UJKqTzU=
-github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492 h1:rcEG5HI490FF0a7zuvxOxen52ddygCfNVjP0XOCMl+M=
 github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492/go.mod h1:9Beu8XsUNNfzml7WBf3QmyPToP1wm1Gj/Vc5UJKqTzU=
+github.com/aquasecurity/go-version v0.0.0-20240603093900-cf8a8d29271d h1:4zour5Sh9chOg+IqIinIcJ3qtr3cIf8FdFY6aArlXBw=
+github.com/aquasecurity/go-version v0.0.0-20240603093900-cf8a8d29271d/go.mod h1:1cPOp4BaQZ1G2F5fnw4dFz6pkOyXJI9KTuak8ghIl3U=
 github.com/aquasecurity/loading v0.0.5 h1:2iq02sPSSMU+ULFPmk0v0lXnK/eZ2e0dRAj/Dl5TvuM=
 github.com/aquasecurity/loading v0.0.5/go.mod h1:NSHeeq1JTDTFuXAe87q4yQ2DX57pXiaQMqq8Zm9HCJA=
 github.com/aquasecurity/table v1.8.0 h1:9ntpSwrUfjrM6/YviArlx/ZBGd6ix8W+MtojQcM7tv0=

--- a/pkg/dependency/parser/dart/pub/parse.go
+++ b/pkg/dependency/parser/dart/pub/parse.go
@@ -4,8 +4,10 @@ import (
 	"golang.org/x/xerrors"
 	"gopkg.in/yaml.v3"
 
+	goversion "github.com/aquasecurity/go-version/pkg/version"
 	"github.com/aquasecurity/trivy/pkg/dependency"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/log"
 	xio "github.com/aquasecurity/trivy/pkg/x/io"
 )
 
@@ -16,20 +18,29 @@ const (
 )
 
 // Parser is a parser for pubspec.lock
-type Parser struct{}
+type Parser struct {
+	logger *log.Logger
+}
 
 func NewParser() *Parser {
-	return &Parser{}
+	return &Parser{
+		logger: log.WithPrefix("pub"),
+	}
 }
 
 type lock struct {
-	Packages map[string]Dep `yaml:"packages"`
+	Packages map[string]Dep    `yaml:"packages"`
+	Sdks     map[string]string `yaml:"sdks"`
 }
 
 type Dep struct {
-	Dependency string `yaml:"dependency"`
-	Version    string `yaml:"version"`
+	Dependency  string      `yaml:"dependency"`
+	Version     string      `yaml:"version"`
+	Source      string      `yaml:"source"`
+	Description Description `yaml:"description"`
 }
+
+type Description string
 
 func (p Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependency, error) {
 	l := &lock{}
@@ -38,21 +49,51 @@ func (p Parser) Parse(r xio.ReadSeekerAt) ([]ftypes.Package, []ftypes.Dependency
 	}
 	var pkgs []ftypes.Package
 	for name, dep := range l.Packages {
+		version := dep.Version
+		if version == "0.0.0" && dep.Source == "sdk" {
+			version = p.findSDKVersion(l, name, dep)
+		}
+
 		// We would like to exclude dev dependencies, but we cannot identify
 		// which indirect dependencies were introduced by dev dependencies
 		// as there are 3 dependency types, "direct main", "direct dev" and "transitive".
 		// It will be confusing if we exclude direct dev dependencies and include transitive dev dependencies.
 		// We decided to keep all dev dependencies until Pub will add support for "transitive main" and "transitive dev".
 		pkg := ftypes.Package{
-			ID:           dependency.ID(ftypes.Pub, name, dep.Version),
+			ID:           dependency.ID(ftypes.Pub, name, version),
 			Name:         name,
-			Version:      dep.Version,
+			Version:      version,
 			Relationship: p.relationship(dep.Dependency),
 		}
 		pkgs = append(pkgs, pkg)
 	}
 
 	return pkgs, nil, nil
+}
+
+// findSDKVersion detects the first version of the SDK constraint specified in the Description.
+// If the constraint is not found, it returns the original version.
+func (p Parser) findSDKVersion(l *lock, name string, dep Dep) string {
+	// Some dependencies use one of the SDK versions.
+	// In this case dep.Version == `0.0.0`.
+	// We can't get versions for these dependencies.
+	// Therefore, we use the first version of the SDK constraint specified in the Description.
+	// See https://github.com/aquasecurity/trivy/issues/6017
+	constraint, ok := l.Sdks[string(dep.Description)]
+	if !ok {
+		return dep.Version
+	}
+
+	v, err := firstVersionOfConstrain(constraint)
+	if err != nil {
+		p.logger.Warn("Unable to get sdk version from constraint", log.Err(err))
+		return dep.Version
+	} else if v == "" {
+		return dep.Version
+	}
+	p.logger.Info("Using the first version of the constraint from the sdk source", log.String("dep", name),
+		log.String("constraint", constraint))
+	return v
 }
 
 func (p Parser) relationship(dep string) ftypes.Relationship {
@@ -63,4 +104,38 @@ func (p Parser) relationship(dep string) ftypes.Relationship {
 		return ftypes.RelationshipIndirect
 	}
 	return ftypes.RelationshipUnknown
+}
+
+// firstVersionOfConstrain returns the first acceptable version for constraint
+func firstVersionOfConstrain(constraint string) (string, error) {
+	css, err := goversion.NewConstraints(constraint)
+	if err != nil {
+		return "", xerrors.Errorf("unable to parse constraints: %w", err)
+	}
+
+	// Dart uses only `>=` and `^` operators:
+	// cf. https://dart.dev/tools/pub/dependencies#traditional-syntax
+	constraints := css.List()
+	if len(constraints) == 0 || len(constraints[0]) == 0 {
+		return "", nil
+	}
+	// We only need to get the first version from the range
+	if constraints[0][0].Operator() != ">=" && constraints[0][0].Operator() != "^" {
+		return "", nil
+	}
+
+	return constraints[0][0].Version(), nil
+}
+
+func (d *Description) UnmarshalYAML(value *yaml.Node) error {
+	var tmp any
+	if err := value.Decode(&tmp); err != nil {
+		return err
+	}
+	// Description can be a string or a struct
+	// We only need a string value for SDK mapping
+	if desc, ok := tmp.(string); ok {
+		*d = Description(desc)
+	}
+	return nil
 }

--- a/pkg/dependency/parser/dart/pub/parse_test.go
+++ b/pkg/dependency/parser/dart/pub/parse_test.go
@@ -31,9 +31,9 @@ func TestParser_Parse(t *testing.T) {
 					Relationship: ftypes.RelationshipDirect,
 				},
 				{
-					ID:           "flutter_test@0.0.0",
+					ID:           "flutter_test@3.3.0",
 					Name:         "flutter_test",
-					Version:      "0.0.0",
+					Version:      "3.3.0",
 					Relationship: ftypes.RelationshipDirect,
 				},
 				{

--- a/pkg/dependency/parser/dart/pub/testdata/happy.lock
+++ b/pkg/dependency/parser/dart/pub/testdata/happy.lock
@@ -22,4 +22,4 @@ packages:
     version: "3.0.6"
 sdks:
   dart: ">=2.18.0 <3.0.0"
-  flutter: ">=3.3.0"
+  flutter: "^3.3.0"

--- a/pkg/dependency/parser/nodejs/pnpm/parse_test.go
+++ b/pkg/dependency/parser/nodejs/pnpm/parse_test.go
@@ -59,6 +59,18 @@ func TestParse(t *testing.T) {
 			want:     pnpmV9,
 			wantDeps: pnpmV9Deps,
 		},
+		{
+			name:     "v9",
+			file:     "testdata/pnpm-lock_v9.yaml",
+			want:     pnpmV9,
+			wantDeps: pnpmV9Deps,
+		},
+		{
+			name:     "v9 with cyclic dependencies import",
+			file:     "testdata/pnpm-lock_v9_cyclic_import.yaml",
+			want:     pnpmV9CyclicImport,
+			wantDeps: pnpmV9CyclicImportDeps,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/dependency/parser/nodejs/pnpm/parse_testcase.go
+++ b/pkg/dependency/parser/nodejs/pnpm/parse_testcase.go
@@ -900,4 +900,68 @@ var (
 			},
 		},
 	}
+
+	pnpmV9CyclicImport = []ftypes.Package{
+		{
+			ID:           "update-browserslist-db@1.0.16",
+			Name:         "update-browserslist-db",
+			Version:      "1.0.16",
+			Relationship: ftypes.RelationshipDirect,
+		},
+		{
+			ID:           "browserslist@4.23.0",
+			Name:         "browserslist",
+			Version:      "4.23.0",
+			Relationship: ftypes.RelationshipIndirect,
+		},
+		{
+			ID:           "caniuse-lite@1.0.30001627",
+			Name:         "caniuse-lite",
+			Version:      "1.0.30001627",
+			Relationship: ftypes.RelationshipIndirect,
+		},
+		{
+			ID:           "electron-to-chromium@1.4.789",
+			Name:         "electron-to-chromium",
+			Version:      "1.4.789",
+			Relationship: ftypes.RelationshipIndirect,
+		},
+		{
+			ID:           "escalade@3.1.2",
+			Name:         "escalade",
+			Version:      "3.1.2",
+			Relationship: ftypes.RelationshipIndirect,
+		},
+		{
+			ID:           "node-releases@2.0.14",
+			Name:         "node-releases",
+			Version:      "2.0.14",
+			Relationship: ftypes.RelationshipIndirect,
+		},
+		{
+			ID:           "picocolors@1.0.1",
+			Name:         "picocolors",
+			Version:      "1.0.1",
+			Relationship: ftypes.RelationshipIndirect,
+		},
+	}
+	pnpmV9CyclicImportDeps = []ftypes.Dependency{
+		{
+			ID: "browserslist@4.23.0",
+			DependsOn: []string{
+				"caniuse-lite@1.0.30001627",
+				"electron-to-chromium@1.4.789",
+				"node-releases@2.0.14",
+				"update-browserslist-db@1.0.16",
+			},
+		},
+		{
+			ID: "update-browserslist-db@1.0.16",
+			DependsOn: []string{
+				"browserslist@4.23.0",
+				"escalade@3.1.2",
+				"picocolors@1.0.1",
+			},
+		},
+	}
 )

--- a/pkg/dependency/parser/nodejs/pnpm/testdata/pnpm-lock_v9_cyclic_import.yaml
+++ b/pkg/dependency/parser/nodejs/pnpm/testdata/pnpm-lock_v9_cyclic_import.yaml
@@ -1,0 +1,67 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      update-browserslist-db:
+        specifier: 1.0.16
+        version: 1.0.16(browserslist@4.23.0)
+
+packages:
+
+  browserslist@4.23.0:
+    resolution: {integrity: sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  caniuse-lite@1.0.30001627:
+    resolution: {integrity: sha512-4zgNiB8nTyV/tHhwZrFs88ryjls/lHiqFhrxCW4qSTeuRByBVnPYpDInchOIySWknznucaf31Z4KYqjfbrecVw==}
+
+  electron-to-chromium@1.4.789:
+    resolution: {integrity: sha512-0VbyiaXoT++Fi2vHGo2ThOeS6X3vgRCWrjPeO2FeIAWL6ItiSJ9BqlH8LfCXe3X1IdcG+S0iLoNaxQWhfZoGzQ==}
+
+  escalade@3.1.2:
+    resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
+    engines: {node: '>=6'}
+
+  node-releases@2.0.14:
+    resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
+
+  picocolors@1.0.1:
+    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
+
+  update-browserslist-db@1.0.16:
+    resolution: {integrity: sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+snapshots:
+
+  browserslist@4.23.0:
+    dependencies:
+      caniuse-lite: 1.0.30001627
+      electron-to-chromium: 1.4.789
+      node-releases: 2.0.14
+      update-browserslist-db: 1.0.16(browserslist@4.23.0)
+
+  caniuse-lite@1.0.30001627: {}
+
+  electron-to-chromium@1.4.789: {}
+
+  escalade@3.1.2: {}
+
+  node-releases@2.0.14: {}
+
+  picocolors@1.0.1: {}
+
+  update-browserslist-db@1.0.16(browserslist@4.23.0):
+    dependencies:
+      browserslist: 4.23.0
+      escalade: 3.1.2
+      picocolors: 1.0.1

--- a/pkg/dependency/parser/python/poetry/parse.go
+++ b/pkg/dependency/parser/python/poetry/parse.go
@@ -105,7 +105,7 @@ func (p *Parser) parseDependencies(deps map[string]any, pkgVersions map[string][
 }
 
 func (p *Parser) parseDependency(name string, versRange any, pkgVersions map[string][]string) (string, error) {
-	name = normalizePkgName(name)
+	name = NormalizePkgName(name)
 	vers, ok := pkgVersions[name]
 	if !ok {
 		return "", xerrors.Errorf("no version found for %q", name)
@@ -149,9 +149,11 @@ func matchVersion(currentVersion, constraint string) (bool, error) {
 	return c.Check(v), nil
 }
 
-func normalizePkgName(name string) string {
+// NormalizePkgName normalizes the package name based on pep-0426
+func NormalizePkgName(name string) string {
 	// The package names don't use `_`, `.` or upper case, but dependency names can contain them.
 	// We need to normalize those names.
+	// cf. https://peps.python.org/pep-0426/#name
 	name = strings.ToLower(name)              // e.g. https://github.com/python-poetry/poetry/blob/c8945eb110aeda611cc6721565d7ad0c657d453a/poetry.lock#L819
 	name = strings.ReplaceAll(name, "_", "-") // e.g. https://github.com/python-poetry/poetry/blob/c8945eb110aeda611cc6721565d7ad0c657d453a/poetry.lock#L50
 	name = strings.ReplaceAll(name, ".", "-") // e.g. https://github.com/python-poetry/poetry/blob/c8945eb110aeda611cc6721565d7ad0c657d453a/poetry.lock#L816

--- a/pkg/fanal/analyzer/language/python/poetry/testdata/happy/pyproject.toml
+++ b/pkg/fanal/analyzer/language/python/poetry/testdata/happy/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Trivy"]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-flask = "^1.0"
+Flask = "^1.0"
 requests = {version = "2.28.1", optional = true}
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v0.53`:
 - https://github.com/knqyf263/trivy/pull/55

## ⚠️ Warning
Conflicts occurred during the cherry-pick and were force-committed without proper resolution. Please carefully review the changes, resolve any remaining conflicts, and ensure the code is in a valid state.