### PR TITLE
fix: backport test [backport: release/v0.53]

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,4 @@ Please ensure to abide by our [Code of Conduct][code-of-conduct] during all inte
 [aquasec]: https://aquasec.com
 [oss]: https://www.aquasec.com/products/open-source-projects/
 [discussions]: https://github.com/aquasecurity/trivy/discussions
+test


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v0.53`:
 - https://github.com/knqyf263/trivy/pull/60