### PR TITLE
fix: backport test [backport: release/v0.53]

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,4 +148,8 @@ Please ensure to abide by our [Code of Conduct][code-of-conduct] during all inte
 [aquasec]: https://aquasec.com
 [oss]: https://www.aquasec.com/products/open-source-projects/
 [discussions]: https://github.com/aquasecurity/trivy/discussions
+<<<<<<< HEAD
 conflict
+=======
+test
+>>>>>>> 3da26391e (fix: backport test (#60))


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `release/v0.53`:
 - https://github.com/knqyf263/trivy/pull/60

## ⚠️ Warning
Conflicts occurred during the cherry-pick and were force-committed without proper resolution. Please carefully review the changes, resolve any remaining conflicts, and ensure the code is in a valid state.